### PR TITLE
Fixed typographical error, changed abilty to ability in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once installed, you'll be able to sort entries on the custom channel fields, mem
 - Add support for sorting custom category fields
 - Improved row styles while in dragging state
 - Updated zip file format to be compatibile with DevDemon Updater
-- Add the abilty to drag and drop categories in the edit categories feature of the publish section's categories tab
+- Add the ability to drag and drop categories in the edit categories feature of the publish section's categories tab
 
 ### 1.3
 - Added sorting to custom member fields


### PR DESCRIPTION
@kevinthompson, I've corrected a typographical error in the documentation of the [draggable](https://github.com/kevinthompson/draggable) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
